### PR TITLE
mtime preservation

### DIFF
--- a/app/qml/harbour-owncloud.qml
+++ b/app/qml/harbour-owncloud.qml
@@ -58,7 +58,7 @@ ApplicationWindow
         target: transfer
         onUploadComplete: {
             if(settings.notifications)
-                notify("Upload complete", name + " uploaded successfully")
+                notify("Upload complete", entry.getName() + " uploaded successfully")
         }
     }
 
@@ -66,7 +66,7 @@ ApplicationWindow
         target: transfer
         onDownloadComplete: {
             if(settings.notifications)
-                notify("Download complete", name + " downloaded successfully")
+                notify("Download complete", entry.getName() + " downloaded successfully")
         }
     }
 
@@ -74,7 +74,7 @@ ApplicationWindow
         target: transfer
         onUploadFailed: {
             if(settings.notifications)
-                notify("Upload failed!", name + " couldn't be uploaded")
+                notify("Upload failed!", entry.getName() + " couldn't be uploaded")
         }
     }
 
@@ -82,7 +82,7 @@ ApplicationWindow
         target: transfer
         onDownloadFailed: {
             if(settings.notifications)
-                notify("Download failed!", name + " couldn't be downloaded")
+                notify("Download failed!", entry.getName() + " couldn't be downloaded")
         }
     }
 

--- a/app/qml/harbour-owncloud.qml
+++ b/app/qml/harbour-owncloud.qml
@@ -86,6 +86,14 @@ ApplicationWindow
         }
     }
 
+    Connections {
+        target: transfer
+        onRemoteMtimeFailed: {
+            if(settings.notifications)
+                notify("Modification time failed!", "Setting mtime failed, status " + status)
+        }
+    }
+
     id: applicationWindow
     initialPage: Component { Login { id: loginPage } }
     cover: Qt.resolvedUrl("cover/CoverPage.qml")

--- a/app/qml/harbour-owncloud.qml
+++ b/app/qml/harbour-owncloud.qml
@@ -88,6 +88,14 @@ ApplicationWindow
 
     Connections {
         target: transfer
+        onLocalMtimeFailed: {
+            if(settings.notifications)
+                notify("Modification time failed!", "Setting mtime failed, errno " + status)
+        }
+    }
+
+    Connections {
+        target: transfer
         onRemoteMtimeFailed: {
             if(settings.notifications)
                 notify("Modification time failed!", "Setting mtime failed, status " + status)

--- a/app/qml/pages/FileBrowser.qml
+++ b/app/qml/pages/FileBrowser.qml
@@ -54,6 +54,8 @@ Page {
     Connections {
         target: transfer
         onUploadComplete: {
+            /// XXX: Would like to pass `entry` in the signal, but it confuses navigation!
+            //remotePath = entry.getRemotePath();
             if(remotePath === pageRoot.remotePath) {
                 refreshListView()
             }

--- a/app/src/owncloudbrowser.cpp
+++ b/app/src/owncloudbrowser.cpp
@@ -6,7 +6,7 @@ OwnCloudBrowser::OwnCloudBrowser(QObject *parent, Settings *settings) :
     this->webdav = 0;
     this->settings = settings;
     this->abortIntended = false;
-    connect(settings, SIGNAL(settingsChanged()), this, SLOT(reloadSettings()));
+    connect(settings, &Settings::settingsChanged, this, &OwnCloudBrowser::reloadSettings);
 
     resetWebdav();
 }
@@ -25,13 +25,13 @@ QWebdav* OwnCloudBrowser::getWebdav()
 void OwnCloudBrowser::resetWebdav()
 {
     if(webdav) {
-        disconnect(webdav, SIGNAL(errorChanged(QString)), this, SLOT(proxyHandleLoginFailed()));
+        disconnect(webdav, &QWebdav::errorChanged, this, &OwnCloudBrowser::proxyHandleLoginFailed);
         disconnect(&parser, 0, 0, 0);
         delete webdav;
     }
     webdav = new QWebdav();
-    connect(webdav, SIGNAL(errorChanged(QString)), this, SLOT(proxyHandleLoginFailed()), Qt::DirectConnection);
-    connect(&parser, SIGNAL(errorChanged(QString)), this, SLOT(proxyHandleLoginFailed()), Qt::DirectConnection);
+    connect(webdav, &QWebdav::errorChanged, this, &OwnCloudBrowser::proxyHandleLoginFailed, Qt::DirectConnection);
+    connect(&parser, &QWebdavDirParser::errorChanged, this, &OwnCloudBrowser::proxyHandleLoginFailed, Qt::DirectConnection);
 }
 
 QWebdav* OwnCloudBrowser::getNewWebdav()
@@ -39,7 +39,7 @@ QWebdav* OwnCloudBrowser::getNewWebdav()
     /* Used for file uploads
      * Helps to not confuse error signals of simultaneous file operations */
     QWebdav* newWebdav = new QWebdav();
-    connect(newWebdav, SIGNAL(finished(QNetworkReply*)), newWebdav, SLOT(deleteLater()), Qt::DirectConnection);
+    connect(newWebdav, &QNetworkAccessManager::finished, newWebdav, &QObject::deleteLater, Qt::DirectConnection);
 
     applySettingsToWebdav(newWebdav);
     return newWebdav;
@@ -64,8 +64,8 @@ void OwnCloudBrowser::applySettingsToWebdav(QWebdav *webdav)
 
 void OwnCloudBrowser::testConnection()
 {
-    connect(webdav, SIGNAL(checkSslCertifcate(const QList<QSslError>&)), this, SLOT(proxyHandleSslError(const QList<QSslError>&)));
-    connect(webdav, SIGNAL(finished(QNetworkReply*)), this, SLOT(testConnectionFinished()), Qt::DirectConnection);
+    connect(webdav, &QWebdav::checkSslCertifcate, this, &OwnCloudBrowser::proxyHandleSslError);
+    connect(webdav, &QNetworkAccessManager::finished, this, &OwnCloudBrowser::testConnectionFinished, Qt::DirectConnection);
 
     parser.listDirectory(webdav, "/");
 }
@@ -74,10 +74,10 @@ void OwnCloudBrowser::testConnectionFinished()
 {
     qDebug() << "BEIDL Finished";
 
-    disconnect(webdav, SIGNAL(checkSslCertifcate(const QList<QSslError>&)), this, SLOT(proxyHandleSslError(const QList<QSslError>&)));
-    disconnect(webdav, SIGNAL(finished(QNetworkReply*)), this, SLOT(testConnectionFinished()));
+    disconnect(webdav, &QWebdav::checkSslCertifcate, this, &OwnCloudBrowser::proxyHandleSslError);
+    disconnect(webdav, &QNetworkAccessManager::finished, this, &OwnCloudBrowser::testConnectionFinished);
 
-    connect(&parser, SIGNAL(finished()), this, SLOT(handleResponse()));
+    connect(&parser, &QWebdavDirParser::finished, this, &OwnCloudBrowser::handleResponse);
     emit loginSucceeded();
 }
 
@@ -92,7 +92,7 @@ void OwnCloudBrowser::proxyHandleLoginFailed()
 {
     if(!abortIntended) {
         qDebug() << "BEIDL Failed";
-        disconnect(&parser, SIGNAL(finished()), this, SLOT(handleResponse()));
+        disconnect(&parser, &QWebdavDirParser::finished, this, &OwnCloudBrowser::handleResponse);
 
         emit loginFailed();
     } else {
@@ -185,8 +185,8 @@ void OwnCloudBrowser::refreshDirectoryContent()
 void OwnCloudBrowser::makeDirectory(QString dirName)
 {
     QWebdav* mkdirWebdav = getNewWebdav();
-    connect(mkdirWebdav, SIGNAL(finished(QNetworkReply*)), this, SLOT(refreshDirectoryContent()), Qt::DirectConnection);
-    connect(mkdirWebdav, SIGNAL(finished(QNetworkReply*)), mkdirWebdav, SLOT(deleteLater()), Qt::DirectConnection);
+    connect(mkdirWebdav, &QNetworkAccessManager::finished, this, &OwnCloudBrowser::refreshDirectoryContent, Qt::DirectConnection);
+    connect(mkdirWebdav, &QNetworkAccessManager::finished, mkdirWebdav, &QObject::deleteLater, Qt::DirectConnection);
     mkdirWebdav->mkdir(currentPath + dirName);
 
     emit refreshStarted(currentPath);
@@ -197,8 +197,8 @@ void OwnCloudBrowser::remove(QString name, bool refresh)
     qDebug() << "Removing " << name;
     QWebdav* rmWebdav = getNewWebdav();
     if(refresh)
-        connect(rmWebdav, SIGNAL(finished(QNetworkReply*)), this, SLOT(refreshDirectoryContent()), Qt::DirectConnection);
-    connect(rmWebdav, SIGNAL(finished(QNetworkReply*)), rmWebdav, SLOT(deleteLater()), Qt::DirectConnection);
+        connect(rmWebdav, &QNetworkAccessManager::finished, this, &OwnCloudBrowser::refreshDirectoryContent, Qt::DirectConnection);
+    connect(rmWebdav, &QNetworkAccessManager::finished, rmWebdav, &QObject::deleteLater, Qt::DirectConnection);
     rmWebdav->remove(name);
 
     if(refresh)

--- a/app/src/shellcommand.cpp
+++ b/app/src/shellcommand.cpp
@@ -8,6 +8,6 @@ void ShellCommand::runCommand(QString command, QStringList args)
 {
     QProcess *proc = new QProcess();
     proc->setReadChannel(QProcess::StandardOutput);
-    connect(proc, SIGNAL(finished(int)), proc, SLOT(deleteLater()));
+    connect(proc, &QProcess::finished, proc, &QObject::deleteLater);
     proc->start(command, args);
 }

--- a/app/src/shellcommand.cpp
+++ b/app/src/shellcommand.cpp
@@ -8,6 +8,6 @@ void ShellCommand::runCommand(QString command, QStringList args)
 {
     QProcess *proc = new QProcess();
     proc->setReadChannel(QProcess::StandardOutput);
-    connect(proc, &QProcess::finished, proc, &QObject::deleteLater);
+    connect(proc, static_cast<void(QProcess::*)(int, QProcess::ExitStatus)>(&QProcess::finished), proc, &QProcess::deleteLater, Qt::DirectConnection);
     proc->start(command, args);
 }

--- a/app/src/transferentry.cpp
+++ b/app/src/transferentry.cpp
@@ -81,22 +81,22 @@ void TransferEntry::startTransfer()
     localFile = new QFile(m_localPath, this);
 
     localFile->open(QFile::ReadWrite);
-    connect(webdav, SIGNAL(finished(QNetworkReply*)), this, SLOT(handleReadComplete()));
+    connect(webdav, &QNetworkAccessManager::finished, this, &TransferEntry::handleReadComplete);
     if(m_direction == DOWN) {
         qDebug() << "Start dl last modified: " << getLastModified().toString("yyyy-MM-ddThh:mm:ss.zzz+t");
         networkReply = webdav->get(m_remotePath, localFile);
-        connect(networkReply, SIGNAL(downloadProgress(qint64,qint64)),
-                this, SLOT(handleProgressChange(qint64,qint64)), Qt::DirectConnection);
+        connect(networkReply, &QNetworkReply::downloadProgress,
+                this, &TransferEntry::handleProgressChange, Qt::DirectConnection);
     } else {
         localFileInfo = new QFileInfo(*localFile);
         this->setLastModified(localFileInfo->lastModified());
         qDebug() << "Start up last modified: " << getLastModified().toString("yyyy-MM-ddThh:mm:ss.zzz+t");
         networkReply = webdav->put(m_remotePath + m_name, localFile);
-        connect(networkReply, SIGNAL(uploadProgress(qint64,qint64)),
-                this, SLOT(handleProgressChange(qint64,qint64)), Qt::DirectConnection);
+        connect(networkReply, &QNetworkReply::uploadProgress,
+                this, &TransferEntry::handleProgressChange, Qt::DirectConnection);
     }
-    connect(this, SIGNAL(destroyed()), networkReply, SLOT(deleteLater()));
-    connect(networkReply, SIGNAL(destroyed()), localFile, SLOT(deleteLater()));
+    connect(this, &QObject::destroyed, networkReply, &QObject::deleteLater);
+    connect(networkReply, &QObject::destroyed, localFile, &QObject::deleteLater);
 }
 
 void TransferEntry::handleProgressChange(qint64 bytes, qint64 bytesTotal)

--- a/app/src/transferentry.cpp
+++ b/app/src/transferentry.cpp
@@ -16,7 +16,6 @@ TransferEntry::TransferEntry(QObject *parent, QWebdav *webdav,
     m_size = size;
     m_progress = 0.0;
     m_direction = direction;
-
     m_open = open;
 }
 
@@ -45,6 +44,11 @@ qint64 TransferEntry::getSize()
     return m_size;
 }
 
+QDateTime TransferEntry::getLastModified()
+{
+    return m_lastModified;
+}
+
 qreal TransferEntry::getProgress()
 {
     return m_progress;
@@ -70,6 +74,11 @@ void TransferEntry::startTransfer()
     qDebug() << "Remote path: " << m_remotePath;
 
     localFile = new QFile(m_localPath, this);
+    localFileInfo = new QFileInfo(*localFile);
+
+    this->m_lastModified = localFileInfo->lastModified();
+    qDebug() << "Start last modified: " << getLastModified().toString("yyyy-MM-ddThh:mm:ss.zzz+t");
+
     localFile->open(QFile::ReadWrite);
     connect(webdav, SIGNAL(finished(QNetworkReply*)), this, SLOT(handleReadComplete()));
     if(m_direction == DOWN) {

--- a/app/src/transferentry.cpp
+++ b/app/src/transferentry.cpp
@@ -54,6 +54,11 @@ qreal TransferEntry::getProgress()
     return m_progress;
 }
 
+void TransferEntry::setLastModified(QDateTime lastModified)
+{
+    this->m_lastModified = lastModified;
+}
+
 void TransferEntry::setProgress(qreal value)
 {
     if(m_progress != value) {
@@ -74,18 +79,18 @@ void TransferEntry::startTransfer()
     qDebug() << "Remote path: " << m_remotePath;
 
     localFile = new QFile(m_localPath, this);
-    localFileInfo = new QFileInfo(*localFile);
-
-    this->m_lastModified = localFileInfo->lastModified();
-    qDebug() << "Start last modified: " << getLastModified().toString("yyyy-MM-ddThh:mm:ss.zzz+t");
 
     localFile->open(QFile::ReadWrite);
     connect(webdav, SIGNAL(finished(QNetworkReply*)), this, SLOT(handleReadComplete()));
     if(m_direction == DOWN) {
+        qDebug() << "Start dl last modified: " << getLastModified().toString("yyyy-MM-ddThh:mm:ss.zzz+t");
         networkReply = webdav->get(m_remotePath, localFile);
         connect(networkReply, SIGNAL(downloadProgress(qint64,qint64)),
                 this, SLOT(handleProgressChange(qint64,qint64)), Qt::DirectConnection);
     } else {
+        localFileInfo = new QFileInfo(*localFile);
+        this->setLastModified(localFileInfo->lastModified());
+        qDebug() << "Start up last modified: " << getLastModified().toString("yyyy-MM-ddThh:mm:ss.zzz+t");
         networkReply = webdav->put(m_remotePath + m_name, localFile);
         connect(networkReply, SIGNAL(uploadProgress(qint64,qint64)),
                 this, SLOT(handleProgressChange(qint64,qint64)), Qt::DirectConnection);

--- a/app/src/transferentry.h
+++ b/app/src/transferentry.h
@@ -39,6 +39,7 @@ public:
     qreal getProgress();
     int getTransferDirection();
 
+    void setLastModified(QDateTime lastModified);
     void setProgress(qreal value);
 
     void startTransfer();

--- a/app/src/transferentry.h
+++ b/app/src/transferentry.h
@@ -34,6 +34,7 @@ public:
     QString getLocalPath();
     QString getRemotePath();
     qint64 getSize();
+    QDateTime getLastModified();
     qreal getProgress();
     int getTransferDirection();
 
@@ -46,6 +47,7 @@ private:
     QWebdav *webdav;
     QNetworkReply *networkReply;
     QFile *localFile;
+    QFileInfo *localFileInfo;
 
     bool m_open;
 
@@ -53,6 +55,7 @@ private:
     QString m_localPath;
     QString m_remotePath;
     qint64 m_size;
+    QDateTime m_lastModified;
     qreal m_progress;
     TransferDirection m_direction;
 

--- a/app/src/transferentry.h
+++ b/app/src/transferentry.h
@@ -30,9 +30,10 @@ public:
 
     ~TransferEntry();
 
-    QString getName();
+    Q_INVOKABLE QString getName();
     QString getLocalPath();
-    QString getRemotePath();
+    // XXX: Q_INVOKABLE getRemotePath can be called in QML if navigation gets fixed, see FileBrowser.qml
+    Q_INVOKABLE QString getRemotePath();
     qint64 getSize();
     QDateTime getLastModified();
     qreal getProgress();

--- a/app/src/transfermanager.cpp
+++ b/app/src/transfermanager.cpp
@@ -236,5 +236,8 @@ void TransferManager::setRemoteMtimeFinished(QNetworkReply *networkReply)
     qDebug() << "setting mtime status " << status;
     if (status < 200 || status >= 300) {
         emit remoteMtimeFailed(status);
+    } else {
+        // Refresh to see the current, new mtime
+        this->browser->getDirectoryContent(this->browser->getCurrentPath());
     }
 }

--- a/app/src/transfermanager.cpp
+++ b/app/src/transfermanager.cpp
@@ -153,6 +153,18 @@ void TransferManager::handleUploadCompleted()
     emit transferingChanged();
 }
 
+void TransferManager::setLocalLastModified(TransferEntry* entry)
+{
+    // TODO: set last modified
+    qDebug() << "Last modified?" << entry->getLastModified().toString("yyyy-MM-ddThh:mm:ss.zzz+t");
+}
+
+void TransferManager::setRemoteLastModified(TransferEntry *entry, QString remotePath)
+{
+    // TODO: webdav request
+    qDebug() << "Last modified?" << entry->getLastModified().toString("yyyy-MM-ddThh:mm:ss.zzz+t");
+}
+
 bool TransferManager::isNotEnqueued(EntryInfo *entry)
 {
     if(entry == NULL)

--- a/app/src/transfermanager.cpp
+++ b/app/src/transfermanager.cpp
@@ -154,13 +154,17 @@ void TransferManager::handleUploadCompleted()
 
 void TransferManager::setLocalLastModified(TransferEntry* entry)
 {
-    QString localName = entry->getLocalPath() + entry->getName();
+    QString localName = entry->getLocalPath();
     struct utimbuf newTimes;
+    int retval;
 
     newTimes.actime = time(NULL);
     newTimes.modtime = entry->getLastModified().toMSecsSinceEpoch() / 1000; // seconds
 
-    utime(localName.toStdString().c_str(), &newTimes);
+    retval = utime(localName.toStdString().c_str(), &newTimes);
+    if (retval != 0 ) {
+        emit localMtimeFailed(errno);
+    }
 
     qDebug() << "Local last modified " << newTimes.modtime;
     disconnect(this, SIGNAL(downloadComplete(TransferEntry*)), this, SLOT(setLocalLastModified(TransferEntry*)));

--- a/app/src/transfermanager.h
+++ b/app/src/transfermanager.h
@@ -41,12 +41,14 @@ signals:
     void downloadFailed(TransferEntry* entry);
     void uploadComplete(TransferEntry* entry, QString remotePath); // Retain remotePath for QML magic
     void uploadFailed(TransferEntry* entry);
+    void remoteMtimeFailed(int status);
 
 public slots:
     void handleDownloadCompleted();
     void handleUploadCompleted();
     void setLocalLastModified(TransferEntry* entry);
     void setRemoteLastModified(TransferEntry* entry, QString remotePath);
+    void setRemoteMtimeFinished(QNetworkReply* networkReply);
 };
 
 #endif // TRANSFERMANAGER_H

--- a/app/src/transfermanager.h
+++ b/app/src/transfermanager.h
@@ -6,6 +6,11 @@
 #include <QMutex>
 #include <QStandardPaths>
 
+#include <time.h>
+#include <unistd.h>
+#include <utime.h>
+#include <sys/stat.h>
+
 #include "owncloudbrowser.h"
 #include "transferentry.h"
 #include "entryinfo.h"

--- a/app/src/transfermanager.h
+++ b/app/src/transfermanager.h
@@ -37,10 +37,10 @@ private:
 signals:
     void transferAdded();
     void transferingChanged();
-    void downloadComplete(QString name, QString localPath);
-    void downloadFailed(QString name);
-    void uploadComplete(QString name, QString remotePath);
-    void uploadFailed(QString name);
+    void downloadComplete(TransferEntry* entry);
+    void downloadFailed(TransferEntry* entry);
+    void uploadComplete(TransferEntry* entry, QString remotePath); // Retain remotePath for QML magic
+    void uploadFailed(TransferEntry* entry);
 
 public slots:
     void handleDownloadCompleted();

--- a/app/src/transfermanager.h
+++ b/app/src/transfermanager.h
@@ -45,7 +45,8 @@ signals:
 public slots:
     void handleDownloadCompleted();
     void handleUploadCompleted();
-
+    void setLocalLastModified(TransferEntry* entry);
+    void setRemoteLastModified(TransferEntry* entry, QString remotePath);
 };
 
 #endif // TRANSFERMANAGER_H

--- a/app/src/transfermanager.h
+++ b/app/src/transfermanager.h
@@ -6,6 +6,7 @@
 #include <QMutex>
 #include <QStandardPaths>
 
+#include <errno.h>
 #include <time.h>
 #include <unistd.h>
 #include <utime.h>
@@ -46,6 +47,7 @@ signals:
     void downloadFailed(TransferEntry* entry);
     void uploadComplete(TransferEntry* entry, QString remotePath); // Retain remotePath for QML magic
     void uploadFailed(TransferEntry* entry);
+    void localMtimeFailed(int status);
     void remoteMtimeFailed(int status);
 
 public slots:

--- a/common/src/settings.cpp
+++ b/common/src/settings.cpp
@@ -16,11 +16,11 @@ Settings::Settings(QObject *parent) :
     m_autoLogin = false;
     m_notifications = true;
 
-    connect(this, SIGNAL(hoststringChanged()), SIGNAL(settingsChanged()));
-    connect(this, SIGNAL(usernameChanged()), SIGNAL(settingsChanged()));
-    connect(this, SIGNAL(passwordChanged()), SIGNAL(settingsChanged()));
-    connect(this, SIGNAL(uploadAutomaticallyChanged()), SIGNAL(settingsChanged()));
-    connect(this, SIGNAL(localPicturesPathChanged()), SIGNAL(settingsChanged()));
+    connect(this, &Settings::hoststringChanged, this, &Settings::settingsChanged);
+    connect(this, &Settings::usernameChanged, this, &Settings::settingsChanged);
+    connect(this, &Settings::passwordChanged, this, &Settings::settingsChanged);
+    connect(this, &Settings::uploadAutomaticallyChanged, this, &Settings::settingsChanged);
+    connect(this, &Settings::localPicturesPathChanged, this, &Settings::settingsChanged);
 }
 
 bool Settings::parseFromAddressString(QString value)

--- a/daemon/filesystem.cpp
+++ b/daemon/filesystem.cpp
@@ -5,7 +5,7 @@
 
 Filesystem::Filesystem()
 {
-    connect(&m_watcher, SIGNAL(directoryChanged(QString)), SLOT(prepareScan(QString)));
+    connect(&m_watcher, &QFileSystemWatcher::directoryChanged, this, &Filesystem::prepareScan);
 }
 
 Filesystem* Filesystem::instance()
@@ -127,7 +127,7 @@ void Filesystem::insertDelay(QString path)
         m_delayLock.unlock();
         scan(path);
     });
-    connect(delay.timer, SIGNAL(timeout()), delay.timer, SLOT(deleteLater()));
+    connect(delay.timer, &QTimer::timeout, delay.timer, &QObject::deleteLater);
     m_delayers.append(delay);
 
     m_delayLock.unlock();

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -18,17 +18,17 @@ int main(int argc, char *argv[]) {
     DBusHandler *dbusHandler = new DBusHandler(uploader);
     NetworkMonitor *netMonitor = NetworkMonitor::instance();
 
-    QObject::connect(fsHandler, SIGNAL(fileFound(QString)), uploader, SLOT(fileFound(QString)));
-    QObject::connect(uploader, SIGNAL(pokeFilesystemScanner()), fsHandler, SLOT(localPathChanged()));
-    QObject::connect(netMonitor, SIGNAL(shouldDownloadChanged(bool)), uploader, SLOT(setOnline(bool)));
+    QObject::connect(fsHandler, &Filesystem::fileFound, uploader, &Uploader::fileFound);
+    QObject::connect(uploader, &Uploader::pokeFilesystemScanner, fsHandler, &Filesystem::localPathChanged);
+    QObject::connect(netMonitor, &NetworkMonitor::shouldDownloadChanged, uploader, &Uploader::setOnline);
 
     // DBus connections
-    QObject::connect(netMonitor, SIGNAL(shouldDownloadChanged(bool)), dbusHandler, SLOT(setOnline(bool)));
-    QObject::connect(uploader, SIGNAL(fileUploaded(QString)), dbusHandler, SIGNAL(fileUploaded(QString)));
-    QObject::connect(uploader, SIGNAL(connectError(QString)), dbusHandler, SIGNAL(connectError(QString)));
-    QObject::connect(uploader, SIGNAL(uploadError(QString)), dbusHandler, SIGNAL(uploadError(QString)));
-    QObject::connect(uploader, SIGNAL(uploadingChanged(bool)), dbusHandler, SIGNAL(uploadingChanged(bool)));
-    QObject::connect(dbusHandler, SIGNAL(configChanged()), uploader, SLOT(settingsChanged()));
+    QObject::connect(netMonitor, &NetworkMonitor::shouldDownloadChanged, dbusHandler, &DBusHandler::setOnline);
+    QObject::connect(uploader, &Uploader::fileUploaded, dbusHandler, &DBusHandler::fileUploaded);
+    QObject::connect(uploader, &Uploader::connectError, dbusHandler, &DBusHandler::connectError);
+    QObject::connect(uploader, &Uploader::uploadError, dbusHandler, &DBusHandler::uploadError);
+    QObject::connect(uploader, &Uploader::uploadingChanged, dbusHandler, &DBusHandler::uploadingChanged);
+    QObject::connect(dbusHandler, &DBusHandler::configChanged, uploader, &Uploader::settingsChanged);
 
     // We only need one instance
     if(!QDBusConnection::sessionBus().registerService("com.github.beidl.HarbourOwncloud.Daemon") ||

--- a/daemon/networkmonitor.cpp
+++ b/daemon/networkmonitor.cpp
@@ -3,10 +3,10 @@
 NetworkMonitor::NetworkMonitor(QObject *parent) : QObject(parent)
 {
     m_shouldDownload = false;
-    connect(&m_configManager, SIGNAL(configurationAdded(QNetworkConfiguration)), SLOT(recheckNetworks()));
-    connect(&m_configManager, SIGNAL(configurationChanged(QNetworkConfiguration)), SLOT(recheckNetworks()));
-    connect(&m_configManager, SIGNAL(configurationRemoved(QNetworkConfiguration)), SLOT(recheckNetworks()));
-    connect(&m_configManager, SIGNAL(onlineStateChanged(bool)), SLOT(recheckNetworks()));
+    connect(&m_configManager, &QNetworkConfigurationManager::configurationAdded, this, &NetworkMonitor::recheckNetworks);
+    connect(&m_configManager, &QNetworkConfigurationManager::configurationChanged, this, &NetworkMonitor::recheckNetworks);
+    connect(&m_configManager, &QNetworkConfigurationManager::configurationRemoved, this, &NetworkMonitor::recheckNetworks);
+    connect(&m_configManager, &QNetworkConfigurationManager::onlineStateChanged, this, &NetworkMonitor::recheckNetworks);
 }
 
 NetworkMonitor::~NetworkMonitor()

--- a/daemon/uploadentry.cpp
+++ b/daemon/uploadentry.cpp
@@ -43,10 +43,10 @@ void UploadEntry::doUpload()
     }
     QNetworkReply *reply = m_connection->put(m_remotePath, file);
     m_currentReply = reply;
-    connect(reply, SIGNAL(finished()), SIGNAL(finished()));
-    connect(reply, SIGNAL(error(QNetworkReply::NetworkError)), SLOT(errorHandler(QNetworkReply::NetworkError)));
-    connect(reply, SIGNAL(finished()), this, SLOT(resetReply()), Qt::DirectConnection);
-    connect(reply, SIGNAL(finished()), reply, SLOT(deleteLater()), Qt::DirectConnection);
+    connect(reply, &QNetworkReply::finished, this, &UploadEntry::finished);
+    connect(reply, &QNetworkReply::error, this, &UploadEntry::errorHandler);
+    connect(reply, &QNetworkReply::finished, this, &UploadEntry::resetReply, Qt::DirectConnection);
+    connect(reply, &QNetworkReply::finished, reply, &QObject::deleteLater, Qt::DirectConnection);
 }
 
 void UploadEntry::errorHandler(QNetworkReply::NetworkError error)
@@ -71,9 +71,9 @@ void UploadEntry::createDirectory()
 {
     QNetworkReply *reply = m_connection->mkdir(m_pathsToCreate.takeFirst());
     m_currentReply = reply;
-    connect(reply, SIGNAL(finished()), SLOT(doUpload()));
-    connect(reply, SIGNAL(error(QNetworkReply::NetworkError)), SLOT(errorHandler(QNetworkReply::NetworkError)));
-    connect(reply, SIGNAL(finished()), this, SLOT(resetReply()), Qt::DirectConnection);
-    connect(reply, SIGNAL(finished()), reply, SLOT(deleteLater()), Qt::DirectConnection);
+    connect(reply, &QNetworkReply::finished, this, &UploadEntry::doUpload);
+    connect(reply, &QNetworkReply::error, this, &UploadEntry::errorHandler);
+    connect(reply, &QNetworkReply::finished, this, &UploadEntry::resetReply, Qt::DirectConnection);
+    connect(reply, &QNetworkReply::finished, reply, &QObject::deleteLater, Qt::DirectConnection);
 }
 

--- a/daemon/uploadentry.cpp
+++ b/daemon/uploadentry.cpp
@@ -44,7 +44,7 @@ void UploadEntry::doUpload()
     QNetworkReply *reply = m_connection->put(m_remotePath, file);
     m_currentReply = reply;
     connect(reply, &QNetworkReply::finished, this, &UploadEntry::finished);
-    connect(reply, &QNetworkReply::error, this, &UploadEntry::errorHandler);
+    connect(reply, static_cast<void(QNetworkReply::*)(QNetworkReply::NetworkError)>(&QNetworkReply::error), this, &UploadEntry::errorHandler);
     connect(reply, &QNetworkReply::finished, this, &UploadEntry::resetReply, Qt::DirectConnection);
     connect(reply, &QNetworkReply::finished, reply, &QObject::deleteLater, Qt::DirectConnection);
 }
@@ -72,7 +72,7 @@ void UploadEntry::createDirectory()
     QNetworkReply *reply = m_connection->mkdir(m_pathsToCreate.takeFirst());
     m_currentReply = reply;
     connect(reply, &QNetworkReply::finished, this, &UploadEntry::doUpload);
-    connect(reply, &QNetworkReply::error, this, &UploadEntry::errorHandler);
+    connect(reply, static_cast<void(QNetworkReply::*)(QNetworkReply::NetworkError)>(&QNetworkReply::error), this, &UploadEntry::errorHandler);
     connect(reply, &QNetworkReply::finished, this, &UploadEntry::resetReply, Qt::DirectConnection);
     connect(reply, &QNetworkReply::finished, reply, &QObject::deleteLater, Qt::DirectConnection);
 }

--- a/daemon/uploader.cpp
+++ b/daemon/uploader.cpp
@@ -14,7 +14,7 @@ Uploader::Uploader(QObject *parent) : QObject(parent),
     setRemoteDirectory();
     applySettings();
 
-    connect(&m_remoteDir, SIGNAL(finished()), SLOT(remoteListingFinished()));
+    connect(&m_remoteDir, &QWebdavDirParser::finished, this, &Uploader::remoteListingFinished);
     connect(&m_remoteDir, &QWebdavDirParser::errorChanged, [](QString error) {
         qDebug() <<  "dir parser error:" << error;
     });
@@ -214,7 +214,7 @@ void Uploader::uploadFile()
         m_uploading = true;
         emit uploadingChanged(true);
         m_currentEntry = new UploadEntry(absolutePath, path, dirsToCreate, &m_connection);
-        connect(m_currentEntry, SIGNAL(finished()), SLOT(uploadFinished()));
+        connect(m_currentEntry, &UploadEntry::finished, this, &Uploader::uploadFinished);
     }
 }
 
@@ -248,8 +248,8 @@ void Uploader::getExistingRemote()
         // Then list the existing files and folders in it
         m_remoteDir.listDirectory(&m_connection, m_remotePath);
     });
-    connect(reply, SIGNAL(finished()), this, SLOT(resetReply()), Qt::DirectConnection);
-    connect(reply, SIGNAL(finished()), reply, SLOT(deleteLater()), Qt::DirectConnection);
+    connect(reply, &QNetworkReply::finished, this, &Uploader::resetReply, Qt::DirectConnection);
+    connect(reply, &QNetworkReply::finished, reply, &QObject::deleteLater, Qt::DirectConnection);
 }
 
 void Uploader::resetReply()


### PR DESCRIPTION
Forgot to make the actual pull request.

This does not have the uploader daemon preserve mtimes, I'm hashing that out in a separate branch as it seems like moving TransferEntry into common makes most sense, but requires a bit of work.

It does, accidentally, include some signal refactoring, as the new Qt5 syntax is safer for compilation.

Throwing this your way for comments, but if you want to just merge it, I've tested it in the emulator
and seems to work, so maybe a bit more of testing is warranted :)
